### PR TITLE
Cancel ConsumeAsync using cancellation token when no message available

### DIFF
--- a/src/ActiveMQ.Net/Consumer.cs
+++ b/src/ActiveMQ.Net/Consumer.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Channels;
+﻿using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Amqp;
 
@@ -23,9 +24,9 @@ namespace ActiveMQ.Net
             });
         }
 
-        public ValueTask<Message> ConsumeAsync()
+        public ValueTask<Message> ConsumeAsync(CancellationToken cancellationToken = default)
         {
-            return _reader.ReadAsync();
+            return _reader.ReadAsync(cancellationToken);
         }
 
         public void Accept(Message message)

--- a/src/ActiveMQ.Net/IConsumer.cs
+++ b/src/ActiveMQ.Net/IConsumer.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace ActiveMQ.Net
 {
     public interface IConsumer : IAsyncDisposable
     {
-        ValueTask<Message> ConsumeAsync();
+        ValueTask<Message> ConsumeAsync(CancellationToken cancellationToken = default);
         void Accept(Message message);
         void Reject(Message message);
     }


### PR DESCRIPTION
It closes #13.