### PR TITLE
Support message properties

### DIFF
--- a/src/ActiveMQ.Net/Message.cs
+++ b/src/ActiveMQ.Net/Message.cs
@@ -2,6 +2,7 @@
 {
     public class Message
     {
+        private Properties _properties;
         internal Amqp.Message InnerMessage { get; }
 
         internal Message(Amqp.Message message)
@@ -13,6 +14,8 @@
         {
             InnerMessage = new Amqp.Message(body);
         }
+
+        public Properties Properties => _properties ??= new Properties(InnerMessage);
 
         public T GetBody<T>()
         {

--- a/src/ActiveMQ.Net/Properties.cs
+++ b/src/ActiveMQ.Net/Properties.cs
@@ -1,0 +1,145 @@
+﻿using System;
+
+namespace ActiveMQ.Net
+{
+    public sealed class Properties
+    {
+        private readonly Amqp.Framing.Properties _innerProperties;
+
+        internal Properties(Amqp.Message innerMessage)
+        {
+            _innerProperties = innerMessage.Properties ??= new Amqp.Framing.Properties();
+        }
+
+        public string MessageId
+        {
+            get => _innerProperties.MessageId;
+            set
+            {
+                if (value != default)
+                    _innerProperties.MessageId = value;
+                else
+                    _innerProperties.ResetField(0);
+            }
+        }
+        public byte[] UserId
+        {
+            get => _innerProperties.UserId;
+            set
+            {
+                if (value != default)
+                    _innerProperties.UserId = value;
+                else
+                    _innerProperties.ResetField(1);
+            }
+        }
+
+        public string Subject
+        {
+            get => _innerProperties.Subject;
+            set
+            {
+                if (value != default)
+                    _innerProperties.Subject = value;
+                else
+                    _innerProperties.ResetField(3);
+            }
+        }
+
+        public string CorrelationId
+        {
+            get => _innerProperties.CorrelationId;
+            set
+            {
+                if (value != default)
+                    _innerProperties.CorrelationId = value;
+                else
+                    _innerProperties.ResetField(5);
+            }
+        }
+
+        public string ContentType
+        {
+            get => _innerProperties.ContentType;
+            set
+            {
+                if (value != default)
+                    _innerProperties.ContentType = value;
+                else
+                    _innerProperties.ResetField(6);
+            }
+        }
+
+        public string ContentEncoding
+        {
+            get => _innerProperties.ContentEncoding;
+            set
+            {
+                if (value != default)
+                    _innerProperties.ContentEncoding = value;
+                else
+                    _innerProperties.ResetField(7);
+            }
+        }
+
+        public DateTime? AbsoluteExpiryTime
+        {
+            get => _innerProperties.HasField(8) ? _innerProperties.AbsoluteExpiryTime : default(DateTime?);
+            set
+            {
+                if (value != default)
+                    _innerProperties.AbsoluteExpiryTime = value.Value;
+                else
+                    _innerProperties.ResetField(8);
+            }
+        }
+
+        public DateTime? CreationTime
+        {
+            get => _innerProperties.HasField(8) ? _innerProperties.CreationTime : default(DateTime?);
+            set
+            {
+                if (value != default)
+                    _innerProperties.CreationTime = value.Value;
+                else
+                    _innerProperties.ResetField(9);
+            }
+        }
+
+        public string GroupId
+        {
+            get => _innerProperties.GroupId;
+            set
+            {
+                if (value != default)
+                    _innerProperties.GroupId = value;
+                else
+                    _innerProperties.ResetField(10);
+            }
+        }
+
+        public uint? GroupSequence
+        {
+            get => _innerProperties.HasField(11) ? _innerProperties.GroupSequence : default(uint?);
+            set
+            {
+                if (value != default)
+                    _innerProperties.GroupSequence = value.Value;
+                else
+                    _innerProperties.ResetField(11);
+            }
+        }
+
+        public string ReplyToGroupId
+        {
+            get => _innerProperties.ReplyToGroupId;
+            set
+            {
+                if (value != default)
+                    _innerProperties.ReplyToGroupId = value;
+                else
+                    _innerProperties.ResetField(12);
+            }
+        }
+    }
+}

--- a/test/ActiveMQ.Net.Tests/ActiveMQNetSpec.cs
+++ b/test/ActiveMQ.Net.Tests/ActiveMQNetSpec.cs
@@ -45,9 +45,9 @@ namespace ActiveMQ.Net.Tests
             return new TestLoggerFactory(_output);
         }
 
-        protected static TestContainerHost CreateOpenedContainerHost(Endpoint endpoint, IHandler handler = null)
+        protected static TestContainerHost CreateOpenedContainerHost(Endpoint endpoint = null, IHandler handler = null)
         {
-            var host = new TestContainerHost(endpoint, handler);
+            var host = CreateContainerHost(endpoint, handler);
             host.Open();
             return host;
         }

--- a/test/ActiveMQ.Net.Tests/MessageSpec.cs
+++ b/test/ActiveMQ.Net.Tests/MessageSpec.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ActiveMQ.Net.Tests
+{
+    public class MessageSpec : ActiveMQNetSpec
+    {
+        public MessageSpec(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Should_set_and_get_message_properties()
+        {
+            using var host = CreateOpenedContainerHost();
+            var messageProcessor = host.CreateMessageProcessor("a1");
+            await using var connection = await CreateConnection(host.Endpoint);
+            var producer = await connection.CreateProducerAsync("a1");
+
+            var message = new Message("text");
+            message.Properties.MessageId = "messageId";
+            message.Properties.UserId = new byte[] { 1, 2, 3, 4, 5 };
+            message.Properties.Subject = "subject";
+            message.Properties.CorrelationId = "correlationId";
+            message.Properties.ContentType = "application/json";
+            message.Properties.ContentEncoding = "gzip";
+            message.Properties.AbsoluteExpiryTime = new DateTime(1991, 1, 25, 0, 0, 0, DateTimeKind.Utc);
+            message.Properties.CreationTime = new DateTime(1991, 8, 22, 0, 0, 0, DateTimeKind.Utc);
+            message.Properties.GroupId = "groupId";
+            message.Properties.GroupSequence = 112u;
+            message.Properties.ReplyToGroupId = "replyToGroupId";
+
+            await producer.SendAsync(message);
+
+            var receivedMsg = messageProcessor.Dequeue(Timeout);
+            Assert.Equal("messageId", receivedMsg.Properties.MessageId);
+            Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, receivedMsg.Properties.UserId);
+            Assert.Equal("subject", receivedMsg.Properties.Subject);
+            Assert.Equal("application/json", receivedMsg.Properties.ContentType);
+            Assert.Equal("gzip", receivedMsg.Properties.ContentEncoding);
+            Assert.Equal(new DateTime(1991, 1, 25, 0, 0, 0, DateTimeKind.Utc), receivedMsg.Properties.AbsoluteExpiryTime);
+            Assert.Equal(new DateTime(1991, 8, 22, 0, 0, 0, DateTimeKind.Utc), receivedMsg.Properties.CreationTime);
+            Assert.Equal("groupId", receivedMsg.Properties.GroupId);
+            Assert.Equal(112u, receivedMsg.Properties.GroupSequence);
+            Assert.Equal("replyToGroupId", receivedMsg.Properties.ReplyToGroupId);
+        }
+
+        [Fact]
+        public async Task Should_reset_message_properties()
+        {
+            using var host = CreateOpenedContainerHost();
+            var messageProcessor = host.CreateMessageProcessor("a1");
+            await using var connection = await CreateConnection(host.Endpoint);
+            var producer = await connection.CreateProducerAsync("a1");
+
+            var message = new Message("text");
+            message.Properties.MessageId = "messageId";
+            message.Properties.UserId = new byte[] { 1, 2, 3, 4, 5 };
+            message.Properties.Subject = "subject";
+            message.Properties.CorrelationId = "correlationId";
+            message.Properties.ContentType = "application/json";
+            message.Properties.ContentEncoding = "gzip";
+            message.Properties.AbsoluteExpiryTime = new DateTime(1991, 1, 25, 0, 0, 0, DateTimeKind.Utc);
+            message.Properties.CreationTime = new DateTime(1991, 8, 22, 0, 0, 0, DateTimeKind.Utc);
+            message.Properties.GroupId = "groupId";
+            message.Properties.GroupSequence = 112u;
+            message.Properties.ReplyToGroupId = "replyToGroupId";
+
+            await producer.SendAsync(message);
+
+            var receivedMsg = messageProcessor.Dequeue(Timeout);
+
+            receivedMsg.Properties.MessageId = null;
+            receivedMsg.Properties.UserId = null;
+            receivedMsg.Properties.Subject = null;
+            receivedMsg.Properties.ContentType = null;
+            receivedMsg.Properties.ContentEncoding = null;
+            receivedMsg.Properties.AbsoluteExpiryTime = null;
+            receivedMsg.Properties.CreationTime = null;
+            receivedMsg.Properties.GroupId = null;
+            receivedMsg.Properties.GroupSequence = null;
+            receivedMsg.Properties.ReplyToGroupId = null;
+
+            await producer.SendAsync(receivedMsg);
+            
+            var resetMsg = messageProcessor.Dequeue(Timeout);
+            
+            Assert.Null(resetMsg.Properties.MessageId);
+            Assert.Null(resetMsg.Properties.UserId);
+            Assert.Null(resetMsg.Properties.Subject);
+            Assert.Null(resetMsg.Properties.ContentType);
+            Assert.Null(resetMsg.Properties.ContentEncoding);
+            Assert.Null(resetMsg.Properties.AbsoluteExpiryTime);
+            Assert.Null(resetMsg.Properties.CreationTime);
+            Assert.Null(resetMsg.Properties.GroupId);
+            Assert.Null(resetMsg.Properties.GroupSequence);
+            Assert.Null(resetMsg.Properties.ReplyToGroupId);
+        }
+    }
+}


### PR DESCRIPTION
This closes #56. PR doesn't cover `To` and `ReplyTo` fields as they should be addressed during work on #15. 