### PR TITLE
Raise ConnectionRecoveryError when connection recovery failed

### DIFF
--- a/src/ActiveMQ.Net/AutoRecovering/AutoRecoveringConnection.cs
+++ b/src/ActiveMQ.Net/AutoRecovering/AutoRecoveringConnection.cs
@@ -117,6 +117,7 @@ namespace ActiveMQ.Net.AutoRecovering
                 catch (Exception e)
                 {
                     Log.MainRecoveryLoopException(_logger, e);
+                    ConnectionRecoveryError?.Invoke(this, new ConnectionRecoveryErrorEventArgs(e));
                 }
             });
         }
@@ -167,6 +168,7 @@ namespace ActiveMQ.Net.AutoRecovering
         public event EventHandler<ConnectionClosedEventArgs> ConnectionClosed;
         
         public event EventHandler<ConnectionRecoveredEventArgs> ConnectionRecovered;
+        public event EventHandler<ConnectionRecoveryErrorEventArgs> ConnectionRecoveryError;
 
         private async Task PrepareRecoverable(IRecoverable recoverable, CancellationToken cancellationToken)
         {

--- a/src/ActiveMQ.Net/Connection.cs
+++ b/src/ActiveMQ.Net/Connection.cs
@@ -79,5 +79,6 @@ namespace ActiveMQ.Net
 #pragma warning disable CS0067
         public event EventHandler<ConnectionRecoveredEventArgs> ConnectionRecovered;
 #pragma warning restore CS0067
+        public event EventHandler<ConnectionRecoveryErrorEventArgs> ConnectionRecoveryError;
     }
 }

--- a/src/ActiveMQ.Net/ConnectionRecoveryErrorEventArgs.cs
+++ b/src/ActiveMQ.Net/ConnectionRecoveryErrorEventArgs.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace ActiveMQ.Net
+{
+    public class ConnectionRecoveryErrorEventArgs : EventArgs
+    {
+        public ConnectionRecoveryErrorEventArgs(Exception exception)
+        {
+            Exception = exception;
+        }
+
+        public Exception Exception { get; }
+    }
+}

--- a/src/ActiveMQ.Net/IConnection.cs
+++ b/src/ActiveMQ.Net/IConnection.cs
@@ -15,5 +15,6 @@ namespace ActiveMQ.Net
         Task<IProducer> CreateProducerAsync(string address, RoutingType routingType, CancellationToken cancellationToken);
         event EventHandler<ConnectionClosedEventArgs> ConnectionClosed;
         event EventHandler<ConnectionRecoveredEventArgs> ConnectionRecovered;
+        event EventHandler<ConnectionRecoveryErrorEventArgs> ConnectionRecoveryError;
     }
 }


### PR DESCRIPTION
This closes #50. 

`ConnectionRecoveryError` is raised when all re-connection attempts failed.