### PR TITLE
DisposeAsync should not throw exception when called on connection that failed to recover

### DIFF
--- a/src/ActiveMQ.Net/AutoRecovering/AutoRecoveringConnection.cs
+++ b/src/ActiveMQ.Net/AutoRecovering/AutoRecoveringConnection.cs
@@ -81,6 +81,8 @@ namespace ActiveMQ.Net.AutoRecovering
 
                         if (!IsOpened)
                         {
+                            await DisposeInnerConnection().ConfigureAwait(false);
+                            
                             foreach (var recoverable in _recoverables.Values)
                             {
                                 recoverable.Suspend();
@@ -194,6 +196,11 @@ namespace ActiveMQ.Net.AutoRecovering
         {
             _recoveryCancellationToken.Cancel();
             await _recoveryLoopTask.ConfigureAwait(false);
+            await DisposeInnerConnection();
+        }
+
+        private async Task DisposeInnerConnection()
+        {
             await _connection.DisposeAsync().ConfigureAwait(false);
             _connection.ConnectionClosed -= OnConnectionClosed;
         }

--- a/src/ActiveMQ.Net/Connection.cs
+++ b/src/ActiveMQ.Net/Connection.cs
@@ -42,7 +42,11 @@ namespace ActiveMQ.Net
 
         public async ValueTask DisposeAsync()
         {
-            await _connection.CloseAsync().ConfigureAwait(false);
+            if (!_closed)
+            {
+                await _connection.CloseAsync().ConfigureAwait(false);
+            }
+
             _connection.Closed -= OnConnectionClosed;
         }
 

--- a/test/ActiveMQ.Net.Tests/AutoRecovering/AutoRecoveringConnectionSpec.cs
+++ b/test/ActiveMQ.Net.Tests/AutoRecovering/AutoRecoveringConnectionSpec.cs
@@ -307,8 +307,6 @@ namespace ActiveMQ.Net.Tests.AutoRecovering
             
             Assert.True(connectionRecoveryFailed.WaitOne(Timeout));
             Assert.NotNull(connectionRecoveryError);
-            
-            await DisposeUtil.DisposeAll(connection);
         }
 
         private static (TestContainerHost host, AutoResetEvent connected) CreateHost()


### PR DESCRIPTION
It closes #66.