### PR TITLE
Add DisposeHostAndWaitUntilConnectionNotified helper method to prevent race condition in tests

### DIFF
--- a/test/ActiveMQ.Net.Tests/AutoRecovering/AutoRecoveringProducerSpec.cs
+++ b/test/ActiveMQ.Net.Tests/AutoRecovering/AutoRecoveringProducerSpec.cs
@@ -51,7 +51,7 @@ namespace ActiveMQ.Net.Tests.AutoRecovering
             var connection = await CreateConnection(endpoint);
             var producer = await connection.CreateProducerAsync("a1", AddressRoutingType.Anycast);
 
-            host1.Dispose();
+            await DisposeHostAndWaitUntilConnectionNotified(host1, connection);
 
             var cts = new CancellationTokenSource(Timeout);
             var produceTask = producer.SendAsync(new Message("foo"), cts.Token);


### PR DESCRIPTION
It closes #80.